### PR TITLE
1) The properties was missing the vault level.

### DIFF
--- a/.env_hooks/cert
+++ b/.env_hooks/cert
@@ -53,11 +53,14 @@ EOF
 	cat > ${DEPLOYMENT_ROOT}/${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}/credentials.yml <<EOF
 ---
 properties:
-  listener:
-    tcp:
-      tls:
-        certificate: (( vault meta.vault_prefix "tls:certificate" ))
-        key:         (( vault meta.vault_prefix "tls:key" ))
+  vault:
+    ha:
+      domain: (( param "Specify the domain your vault servers are in" ))
+    listener:
+      tcp:
+        tls:
+          certificate: (( vault meta.vault_prefix "tls:certificate" ))
+          key:         (( vault meta.vault_prefix "tls:key" ))
 EOF
 
 	safe write "${VAULT_PREFIX}/tls" "certificate@${where}/vault.pem" "key@${where}/vault.key"


### PR DESCRIPTION
1) The properties attribute for the credentials.yml was missing the vault level.
2) added properties.vault.ha.domain parameter since HA cannot work
without it.  It is required for the vault advertise_addr parameter
generation when HA mode is activated. 
