### PR TITLE
Show targets when creating SSL cert and adding it to Vault

### DIFF
--- a/.env_hooks/cert
+++ b/.env_hooks/cert
@@ -12,7 +12,7 @@ case ${CONFIRM} in
 	echo
 
 	if [[ -f ~/.saferc ]]; then
-		safe target
+		safe targets
 		echo -n "Is this the Vault you wish to store this Vault's certificate/key in?  [yes/no] "
 		read CONFIRM
 		if [[ ${CONFIRM} != "yes" ]]; then


### PR DESCRIPTION
The `safe target` command only shows help text.  `safe targets` will show what is targeted
